### PR TITLE
Added build and pycache, pyc ignores.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 dist/
 *.egg-info/
+build/
+__pycache__
+*.pyc


### PR DESCRIPTION
When running under Python3 we have **pycache** garbage lying around.
pyc from Python2 are also left lying around.
A build/ directory after setup.py is also looking to be tracked.
