### PR TITLE
{/.. is not considered to be in_re

### DIFF
--- a/jsmin/__init__.py
+++ b/jsmin/__init__.py
@@ -213,7 +213,7 @@ class JavascriptMinify(object):
                     next1 = next2
                     next2 = read(1)
                 else:
-                    in_re = previous_non_space in '(,=:[?!&|;' or self.is_return  # literal regular expression
+                    in_re = previous_non_space in '{(,=:[?!&|;' or self.is_return  # literal regular expression
                     write('/')
             else:
                 if do_space:


### PR DESCRIPTION
See issue #1, but basically since `{\` does not trigger `in_re`, a `//`
chain inside the regular expression literal will be interpreted as a
one line comment and removed completely (test case `{/\//}` which
results in a minified syntax error due to mismatched bracket when it's
turned into `{/\` (single line comment removed).

Not sure if this breaks anything but all tests pass.
