### PR TITLE
Refactor regex literal handling into a tighter loop

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email='dave@st.germa.in',
     maintainer='Tikitu de Jager',
     maintainer_email='tikitu+jsmin@logophile.org',
-    test_suite='jsmin.test.JsTests',
+    test_suite='jsmin.test',
     license='MIT License',
     url='https://bitbucket.org/dcs/jsmin/',
     classifiers=[


### PR DESCRIPTION
This lets us better take into account the regex escaping rules (e.g.
subtle stuff like "a / occurring inside a [] character class doesn't
end the regex literal").
