### PR TITLE
Preserve copyright notices

### DIFF
--- a/jsmin/__init__.py
+++ b/jsmin/__init__.py
@@ -234,9 +234,18 @@ class JavascriptMinify(object):
         # Skip past first /* and avoid catching on /*/...*/
         next1 = read(1)
         next2 = read(1)
+
+        comment_buffer = '/*'
         while next1 != '*' or next2 != '/':
+            comment_buffer += next1
             next1 = next2
             next2 = read(1)
+
+        if comment_buffer.startswith("/*!"):
+            # comment needs preserving
+            self.outs.write(comment_buffer)
+            self.outs.write("*/\n")
+
 
     def newline(self, previous_non_space, next2, do_newline):
         read = self.ins.read

--- a/jsmin/test.py
+++ b/jsmin/test.py
@@ -533,7 +533,7 @@ b} and not ${2 * a + "b"}.`'''
         self.assertMinified(original , 'var re=/\d{4}/\ng=10')
 
     def test_preserve_copyright(self):
-        original = '/*! Copyright blah blah */ var a;'
+        original = "/*! Copyright blah blah */\nvar a;"
         self.assertMinified(original, original)
 
 

--- a/jsmin/test.py
+++ b/jsmin/test.py
@@ -532,6 +532,10 @@ b} and not ${2 * a + "b"}.`'''
             g = 10'''
         self.assertMinified(original , 'var re=/\d{4}/\ng=10')
 
+    def test_preserve_copyright(self):
+        original = '/*! Copyright blah blah */ var a;'
+        self.assertMinified(original, original)
+
 
 class RegexTests(unittest.TestCase):
 

--- a/jsmin/test.py
+++ b/jsmin/test.py
@@ -533,8 +533,25 @@ b} and not ${2 * a + "b"}.`'''
         self.assertMinified(original , 'var re=/\d{4}/\ng=10')
 
     def test_preserve_copyright(self):
-        original = "/*! Copyright blah blah */\nvar a;"
-        self.assertMinified(original, original)
+        original = '''
+            function this() {
+                /*! Copyright year person */
+                console.log('hello!');
+            }
+
+            /*! Copyright blah blah
+             *
+             *  Some other text
+             */
+
+            var a;
+        '''
+        expected = """function this(){/*! Copyright year person */
+console.log('hello!');}/*! Copyright blah blah
+             *
+             *  Some other text
+             */\n\nvar a;"""
+        self.assertMinified(original, expected)
 
 
 class RegexTests(unittest.TestCase):


### PR DESCRIPTION
Preserve copyright notices in "loud" comments as used by projects such as jQuery.
