### PR TITLE
Update travis python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
-  - "3.3"
-  - "3.2"
+  - "3.7"
+  - "3.6"
+  - "3.5"
+  - "3.4"
   - "2.7"
-  - "2.6"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
 # command to run tests, e.g. python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.7"
   - "3.6"
   - "3.5"
   - "3.4"
@@ -9,3 +8,9 @@ python:
 install:
 # command to run tests, e.g. python setup.py test
 script:  python setup.py test
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: required


### PR DESCRIPTION
Python 3.3 reached end-of-life in 2017, and Python 2.6 reached end-of-life in 2013. It seems appropriate to remove these and update the travis file to support newer versions of Python (which all work as expected in my testing).