### PR TITLE
Travis CI: 'sudo' is no longer required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ matrix:
   include:
     - python: 3.7
       dist: xenial
-      sudo: required


### PR DESCRIPTION
[Travis are now recommending removing __sudo__](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)